### PR TITLE
remove boto3 hardcoded dependency

### DIFF
--- a/lib/layer/requirements.txt
+++ b/lib/layer/requirements.txt
@@ -1,4 +1,3 @@
 opensearch-py==2.3.1
-boto3==1.35.3
 crhelper==2.0.11
 requests-aws4auth==1.2.3


### PR DESCRIPTION
Not needed, use the boto3 version from the runtime.

Use a hardcoded boto3 version allow to use the automatic runtime update.
